### PR TITLE
if image can't be upload snapshot is set to syn error state

### DIFF
--- a/src/redux/middleware.js
+++ b/src/redux/middleware.js
@@ -17,6 +17,7 @@ export const submitDraftWithImages = store => next => action => {
     //Submit draft without pictures anyway
     console.log('LOAD IMAGES ROLLBACK')
     console.log('Sending draf without images')
+    console.log(action)
     /* let reduce = submitDraft(action.env, action.token, action.id, {
       ...action.draft,
       pictures: []

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -145,8 +145,15 @@ export const syncStatus = (state = [], action) => {
       }
     }
     case SUBMIT_DRAFT_COMMIT: {
-      console.log('Removing id to synced: ', action.meta.id)
+      console.log(
+        'SUBMIT_DRAFT_COMMIT -- Removing id to synced: ',
+        action.meta.id
+      )
       return state.filter(draftId => draftId !== action.meta.id)
+    }
+    case LOAD_IMAGES_ROLLBACK: {
+      console.log('LOAD_IMAGES_ROLLBACK -- Removing id to synced: ', action.id)
+      return state.filter(draftId => draftId !== action.id)
     }
     default:
       return state
@@ -303,7 +310,7 @@ export const drafts = (state = [], action) => {
         draft.draftId === action.id
           ? {
               ...draft,
-              status: 'Pending sync'
+              status: 'Sync error'
             }
           : draft
       )


### PR DESCRIPTION
This issue change the way we process the snapshot if it fails because images have been deleted or was unable to send images to the backend due to offline mode. 
Every time the image upload fails, it will create a Snapshot in ``Sync Error``status so the user can add/delete new images or check if the data is correct. 