### PR TITLE
Guillecaba fix non stop audio

### DIFF
--- a/src/screens/lifemap/Question.js
+++ b/src/screens/lifemap/Question.js
@@ -131,7 +131,7 @@ export class Question extends Component {
         survey: this.survey,
       });
     } else if (this.step + 1 >= this.indicators.length && answer === 0) {
-      return this.props.navigation.navigate('Skipped', {
+      return this.props.navigation.replace('Skipped', {
         draftId: this.draftId,
         survey: this.survey,
       });
@@ -141,13 +141,13 @@ export class Question extends Component {
         answer !== 0) ||
       skippedQuestions.length === 0
     ) {
-      return this.props.navigation.navigate('Overview', {
+      return this.props.navigation.replace('Overview', {
         resumeDraft: false,
         draftId: this.draftId,
         survey: this.survey,
       });
     } else {
-      return this.props.navigation.navigate('Skipped', {
+      return this.props.navigation.replace('Skipped', {
         draftId: this.draftId,
         survey: this.survey,
       });


### PR DESCRIPTION

If you are playing an audio during the last indicator of the lifemap and then select an answer or skip, it should stop the audio, not continue playing.