### PR TITLE
Guillecaba Restore target sdk to 29

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,9 +4,10 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.2"
         minSdkVersion = 16
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 29
+        targetSdkVersion = 29
         googlePlayServicesVersion  = "17.0.0"
+        androidXCore = "1.6.0"
     }
     repositories {
         google()


### PR DESCRIPTION
In the last week, React native build automatically upgraded aandroidx.core: core: 1.7.0-alpha01, which depends on SDK version 30.
Previously the solution used was to upload to sdk 30 in the build.gradle
But in view of the errors this caused, for now it is better to make it point androidXCore to a stable version, while keeping the sdk at 29.

In the short term future it will be necessary to update React native to 0.64